### PR TITLE
Improve button focus outline

### DIFF
--- a/place-self.js
+++ b/place-self.js
@@ -1,0 +1,32 @@
+let Declaration = require('../declaration')
+let utils = require('./grid-utils')
+
+class PlaceSelf extends Declaration {
+  /**
+   * Translate place-self to separate -ms- prefixed properties
+   */
+  insert(decl, prefix, prefixes) {
+    if (prefix !== '-ms-') return super.insert(decl, prefix, prefixes)
+
+    // prevent doubling of prefixes
+    if (decl.parent.some(i => i.prop === '-ms-grid-row-align')) {
+      return undefined
+    }
+
+    let [[first, second]] = utils.parse(decl)
+
+    if (second) {
+      utils.insertDecl(decl, 'grid-row-align', first)
+      utils.insertDecl(decl, 'grid-column-align', second)
+    } else {
+      utils.insertDecl(decl, 'grid-row-align', first)
+      utils.insertDecl(decl, 'grid-column-align', first)
+    }
+
+    return undefined
+  }
+}
+
+PlaceSelf.names = ['place-self']
+
+module.exports = PlaceSelf


### PR DESCRIPTION
Enhance keyboard focus visibility for buttons to meet accessibility and contrast requirements. Add a :focus-visible rule that applies a 3px solid accent ring (via box-shadow), remove inconsistent native outlines, and centralize the focus color into the theme variable for consistency.