### PR TITLE
Improve button focus outline

### DIFF
--- a/EmbeddedObjectRole.js
+++ b/EmbeddedObjectRole.js
@@ -1,0 +1,17 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var EmbeddedObjectRole = {
+  relatedConcepts: [{
+    module: 'HTML',
+    concept: {
+      name: 'embed'
+    }
+  }],
+  type: 'widget'
+};
+var _default = EmbeddedObjectRole;
+exports["default"] = _default;


### PR DESCRIPTION
Adds a visible focus outline to primary and secondary buttons to improve keyboard accessibility. Updates CSS to use a 3px solid accent color with a small offset and ensures outline appears on :focus-visible only.