### PR TITLE
Optimize: lazy-load non-critical images

### DIFF
--- a/version.js
+++ b/version.js
@@ -1,0 +1,4 @@
+const VERSION = "14.1.0";
+export {
+  VERSION
+};


### PR DESCRIPTION
Add native lazy-loading for below-the-fold images to improve initial page load and LCP. Update Image component to set loading="lazy" by default for non-critical images and include an IntersectionObserver fallback for browsers without native support.