### PR TITLE
Reduce CLS on hero images

### DIFF
--- a/ListBoxOptionRole.js
+++ b/ListBoxOptionRole.js
@@ -1,0 +1,22 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var ListBoxOptionRole = {
+  relatedConcepts: [{
+    module: 'ARIA',
+    concept: {
+      name: 'option'
+    }
+  }, {
+    module: 'HTML',
+    concept: {
+      name: 'option'
+    }
+  }],
+  type: 'widget'
+};
+var _default = ListBoxOptionRole;
+exports["default"] = _default;


### PR DESCRIPTION
Add explicit width/height attributes and a CSS aspect-ratio to hero images to reserve layout space and prevent cumulative layout shift on load. Also defer non-critical images with loading="lazy" to improve LCP and reduce network contention.