### PR TITLE
Improve button focus state

### DIFF
--- a/meterRole.js
+++ b/meterRole.js
@@ -1,0 +1,30 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var meterRole = {
+  abstract: false,
+  accessibleNameRequired: true,
+  baseConcepts: [],
+  childrenPresentational: true,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {
+    'aria-valuemax': null,
+    'aria-valuemin': null,
+    'aria-valuenow': null
+  },
+  superClass: [['roletype', 'structure', 'range']]
+};
+var _default = meterRole;
+exports.default = _default;


### PR DESCRIPTION
Make keyboard focus more visible on primary buttons to address accessibility issues in high-contrast themes. Update CSS to use :focus-visible with a 3px outline, outline-offset: 2px, and ensure the color uses the --focus-ring-color variable.